### PR TITLE
Add option to keep empty stacks instead of deleting them

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -5,6 +5,8 @@
   "SETTINGS.lsClearInventoryHint": "If enabled, all existing items will be removed from the Loot Sheet before adding new items from the rollable table. If disabled, existing items will remain.",
   "SETTINGS.lsChangeIconForSpellScrollsTitle": "Change icon for Spell Scrolls?",
   "SETTINGS.lsChangeIconForSpellScrollsHint": "Changes the icon for spell scrolls to a scroll icon. If left unchecked, retains the spell's icon.",
+  "SETTINGS.lsRemoveEmptyStackTitle": "Delete empty stacks",
+  "SETTINGS.lsRemoveEmptyStackHint": "Deletes items that have quantity set to 0. If disabled, the items will remain with quantity of 0.",
   
   "ERROR.lsItemInvalidQuantity": "Item quantity invalid.",
   "ERROR.lsChangingSettingsFor": "Error changing settings for \"{name}\".",

--- a/lootsheetnpcpf1.js
+++ b/lootsheetnpcpf1.js
@@ -1158,6 +1158,15 @@ Hooks.once("init", () => {
     type: Boolean
   });
 
+  game.settings.register(LootSheetPf1NPC.MODULENAME, "removeEmptyStacks", {
+    name: game.i18n.localize("SETTINGS.lsRemoveEmptyStackTitle"),
+    hint: game.i18n.localize("SETTINGS.lsRemoveEmptyStackHint"),
+    scope: "world",
+    config: true,
+    default: true,
+    type: Boolean
+  });
+
   /*******************************************
    *          SOCKET HANDLING!
    *******************************************/

--- a/scripts/actions.js
+++ b/scripts/actions.js
@@ -70,7 +70,8 @@ export class LootSheetActions {
       "data.quantity": item.data.quantity - quantity
     };
 
-    if (update["data.quantity"] === 0) {
+    let removeEmptyStacks = game.settings.get("lootsheetnpcpf1", "removeEmptyStacks");
+    if (update["data.quantity"] === 0 && removeEmptyStacks) {
       source.deleteEmbeddedEntity("OwnedItem", itemId);
     } else {
       source.updateEmbeddedEntity("OwnedItem", update);


### PR DESCRIPTION
Aids repopulating merchants as necessary by keeping the empty stacks instead of throwing them away.

Defaults to current behaviour of deleting stacks.