### PR TITLE
Fix selling giving odd values

### DIFF
--- a/lootsheetnpcpf1.js
+++ b/lootsheetnpcpf1.js
@@ -597,27 +597,24 @@ class LootSheetPf1NPC extends ActorSheetPFNPC {
     Dialog.confirm({
       title: game.i18n.localize("ls.convertLootTitle"),
       content: game.i18n.localize("ls.convertLootMessage"),
-      yes: () => {
-        let total = 0
+      yes: async () => {
+        let totalGP = 0
         let deleteList = []
         this.actor.items.forEach( item  => {
            if (["weapon", "equipment", "consumable", "tool", "loot"].indexOf(item.type) >= 0) {
              let itemCost = LootSheetActions.getItemCost(item.data)
-             if( item.data.data.subType !== "tradeGoods" ) {
-               itemCost = Math.round(itemCost / 2)
-             }
-             total += itemCost * item.data.data.quantity
+             if( item.data.data.subType !== "tradeGoods" )
+               itemCost = itemCost / 2;
+             totalGP += itemCost * item.data.data.quantity
              deleteList.push(item._id)
            }
           }
         );
-        
-        let funds = duplicate(this.actor.data.data.currency)
-        funds.gp = Number(funds.gp)
-        funds.gp += Math.round(total)
-        
-        this.actor.update({ "data.currency": funds });
-        this.actor.deleteEmbeddedEntity("OwnedItem", deleteList)
+
+        let funds = LootSheetActions.spreadFunds(totalGP, duplicate(this.actor.data.data.currency));
+
+        await this.actor.update({ "data.currency": funds });
+        await this.actor.deleteEmbeddedEntity("OwnedItem", deleteList)
       },
       no: () => {}
     });
@@ -1262,4 +1259,3 @@ Hooks.on("getActorDirectoryEntryContext", (html, options) => {
     },
   });
 });
-

--- a/scripts/actions.js
+++ b/scripts/actions.js
@@ -89,7 +89,6 @@ export class LootSheetActions {
   }
 
   static spreadFunds(totalGP, funds) {
-    console.log(`WIP - spreading ${totalGP}`);
     const gpBare = Math.floor(totalGP),
       spLeftOver = (totalGP - gpBare) * 10,
       spBare = Math.floor(spLeftOver),
@@ -98,7 +97,6 @@ export class LootSheetActions {
     funds.gp += gpBare;
     funds.sp += spBare;
     funds.cp += cpBare;
-    console.log(`WIP - spread to ${funds.gp} gp + ${funds.sp} sp + ${funds.cp} cp`);
     return funds;
   }
 


### PR DESCRIPTION
This eliminates the forcing of all values to gold and actually spreads it over to the different monetary units.

On the side it also removes double update which likely causes some other problems with selling.


Closes #4