### PR TITLE
Added the ability for the GM to adjust the sale value of loot.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -64,7 +64,7 @@
   "ls.priceModifierText": "Use this slider to increase or decrease the price of all items in this inventory.",
   
   "ls.convertLootTitle": "Convert to coins",
-  "ls.convertLootMessage": "Are you sure you want to convert all items into coins? Items will be sold for 50% of their price (except TradeGoods). Unidentified items will be sold based on unidentified cost.",
+  "ls.convertLootMessage": "Are you sure you want to convert all items into coins? Items will be sold for {saleValue}% of their price (except TradeGoods). Unidentified items will be sold based on unidentified cost.",
   
   "ls.lootName": "Merchant/Loot Name",
   "ls.noAccesToSheet": "You don't have access to that Loot/Merchant sheet!",
@@ -108,6 +108,8 @@
   "ls.maxCapacityTooltip": "Maximum number of items in the loot (empty or 0 means unlimited)",
   "ls.maxLoad": "Max load",
   "ls.maxLoadTooltip": "Max weight that can be put in the loot (empty or 0 means unlimited)",
+  "ls.saleValue": "Sale Value",
+  "ls.saleValueTooltip": "The percentage of value that non trade goods will be sold for (empty means 50%)",
   
   "ls.pp": "pp",
   "ls.gp": "gp",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -64,7 +64,7 @@
   "ls.priceModifierText": "Utiliser le curseur pour augmenter ou réduire le prix de tous les objets de l'inventaire.",
   
   "ls.convertLootTitle": "Convertir en pièces",
-  "ls.convertLootMessage": "Êtes-vous sûr de vouloir convertir tous les objets en pièces d'or? Les objets seront vendus pour 50% de leur valeur (sauf les objets d'échange). Les objets non-identifiés seront vendus à leur prix non-identifié (si disponible).",
+  "ls.convertLootMessage": "Êtes-vous sûr de vouloir convertir tous les objets en pièces d'or? Les objets seront vendus pour {saleValue}% de leur valeur (sauf les objets d'échange). Les objets non-identifiés seront vendus à leur prix non-identifié (si disponible).",
   
   "ls.lootName": "Nom du Marchant/Butin",
   "ls.noAccesToSheet": "Vous n'avez pas accès à cette feuille de marchant/butin!",
@@ -107,6 +107,8 @@
   "ls.maxCapacityTooltip": "Nombre d'objets maximum dans le butin (vide ou 0 signifie aucune limite)",
   "ls.maxLoad": "Charge max",
   "ls.maxLoadTooltip": "Poids maximal qui peut être déposé dans le butin (vide ou 0 signifie aucune limite)",
+  "ls.saleValue": "Valeur de vente",
+  "ls.saleValueTooltip": "Le pourcentage de la valeur pour laquelle les biens non commerciaux seront vendus (vide signifie 50 %)",
   
   "ls.pp": "pp",
   "ls.gp": "po",

--- a/lang/it.json
+++ b/lang/it.json
@@ -64,7 +64,7 @@
   "ls.priceModifierText": "Usa questo cursore per aumentare o diminuire il prezzo di tutti gli articoli in questo inventario.",
   
   "ls.convertLootTitle": "Converti in Monete",
-  "ls.convertLootMessage": "Sei sicuro di voler convertire tutti gli oggetti in monete? Gli articoli saranno venduti al 50% del loro prezzo (eccetto la merce di scambio). Gli articoli non identificati verranno venduti in base al costo da non identificato.",
+  "ls.convertLootMessage": "Sei sicuro di voler convertire tutti gli oggetti in monete? Gli articoli saranno venduti al {saleValue}% del loro prezzo (eccetto la merce di scambio). Gli articoli non identificati verranno venduti in base al costo da non identificato.",
   
   "ls.lootName": "Nome Mercante/Bottino",
   "ls.noAccesToSheet": "Non hai accesso alla scheda di quel Bottino/Mercante!",
@@ -108,6 +108,8 @@
   "ls.maxCapacityTooltip": "Massimo numero di oggetti nel bottino (vuoto o 0 = illimitato)",
   "ls.maxLoad": "Carico Massimo",
   "ls.maxLoadTooltip": "Massimo peso supportato dal bottino (vuoto o 0 = illimitato)",
+  "ls.saleValue": "Valore di vendita",
+  "ls.saleValueTooltip": "La percentuale di valore per cui verranno venduti i beni non commerciali (vuoto significa 50%)",
   
   "ls.pp": "mp",
   "ls.gp": "mo",

--- a/modules/actions.js
+++ b/modules/actions.js
@@ -408,7 +408,7 @@ export class LootSheetActions {
   /**
    * Returns the sale value of an item
    */
-  static getItemSaleValue(item) {
+  static getItemSaleValue(item, saleValue) {
     if(item.type == "container") {
       let total = 0;
       item.items.forEach(i => total += LootSheetActions.getItemSaleValue(i))
@@ -416,7 +416,7 @@ export class LootSheetActions {
     } else if (["weapon", "equipment", "consumable", "tool", "loot"].indexOf(item.type) >= 0) {
       let itemCost = LootSheetActions.getItemCost(item.data)
       if( item.data.data.subType !== "tradeGoods" )
-        itemCost = itemCost / 2;
+        itemCost = itemCost * saleValue;
       return itemCost * item.data.data.quantity
     }
     return 0;

--- a/modules/lootsheet-npc.js
+++ b/modules/lootsheet-npc.js
@@ -109,6 +109,7 @@ export class LootSheetPf1NPC extends game.pf1.applications.ActorSheetPFNPC {
     let totalPrice = 0
     let maxCapacity = await this.actor.getFlag(LootSheetConstants.MODULENAME, "maxCapacity") || 0;
     let maxLoad = await this.actor.getFlag(LootSheetConstants.MODULENAME, "maxLoad") || 0;
+    let saleValue = await this.actor.getFlag(LootSheetConstants.MODULENAME, "saleValue") || 50;
     
     Object.keys(sheetData.actor.features).forEach( f => sheetData.actor.features[f].items.forEach( i => {  
       // specify if empty
@@ -134,6 +135,7 @@ export class LootSheetPf1NPC extends game.pf1.applications.ActorSheetPFNPC {
     sheetData.weightWarning = maxLoad <= 0 || maxLoad >= totalWeight ? "" : "warn"
     sheetData.totalPrice = totalPrice
     sheetData.weightUnit = game.settings.get("pf1", "units") == "metric" ? game.i18n.localize("PF1.Kgs") : game.i18n.localize("PF1.Lbs")
+    sheetData.saleValue = saleValue < 0 ? 0 : saleValue;
         
     // workaround to get all flags
     const rolltableName = await this.actor.getFlag(LootSheetConstants.MODULENAME, "rolltable");
@@ -590,12 +592,13 @@ export class LootSheetPf1NPC extends game.pf1.applications.ActorSheetPFNPC {
      
     Dialog.confirm({
       title: game.i18n.localize("ls.convertLootTitle"),
-      content: game.i18n.localize("ls.convertLootMessage"),
+      content: game.i18n.format("ls.convertLootMessage", {saleValue: this.actor.getFlag(LootSheetConstants.MODULENAME, "saleValue")}),
       yes: async () => {
         let totalGP = 0
         let deleteList = []
+        let saleValue = this.actor.getFlag(LootSheetConstants.MODULENAME, "saleValue") / 100;
         this.actor.items.forEach( item  => {
-          totalGP += LootSheetActions.getItemSaleValue(item)
+          totalGP += LootSheetActions.getItemSaleValue(item, saleValue)
           deleteList.push(item.id)
         });
 

--- a/template/npc-sheet-gmpart.html
+++ b/template/npc-sheet-gmpart.html
@@ -54,6 +54,10 @@
                         <div class="flexcol"><h4>{{localize "ls.maxLoad"}} <i class="fas fa-info-circle help" title="{{localize "ls.maxLoadTooltip"}}"></i></h4></div>
                         <div class="flexcol"><input name="data.flags.lootsheetnpcpf1.maxLoad" type="text" data-dtype="Number" placeholder="e.g. 200" value="{{flags.lootsheetnpcpf1.maxLoad}}"/></div>
                     </div>
+                    <div class="flexrow">
+                        <div class="flexcol"><h4>{{localize "ls.saleValue"}}<i class="fas fa-info-circle help" title="{{localize "ls.saleValueTooltip"}}"></i></h4></div>
+                        <div class="flexcol"><input name="data.flags.lootsheetnpcpf1.saleValue" type="text" data-dtype="Number" placeholder="e.g. 50" value="{{flags.lootsheetnpcpf1.saleValue}}"/></div>
+                    </div>
                     <h3 class="gm-header"><i class="fas fa-coins"></i> {{localize "ls.coinDistribution"}}</h3>
                     <ol class="coins-list">
                         {{#each flags.loot.currency as |c i|}}


### PR DESCRIPTION
The GM now has access to a "Sale Value" parameter that defaults to 50, this represents the % that non trade goods will sell for at the vendor, which makes it easy to adjust based on things like diplomacy rolls and such.

![image](https://user-images.githubusercontent.com/6026593/151982075-116689c6-fca9-409f-ba25-74c2e26593ba.png)
